### PR TITLE
Add dynamic cell sizes

### DIFF
--- a/Classes/NBNAssetCell.h
+++ b/Classes/NBNAssetCell.h
@@ -4,6 +4,4 @@
 
 - (void)configureWithAsset:(UIImage *)image;
 
-+ (CGSize)size;
-
 @end

--- a/Classes/NBNAssetCell.m
+++ b/Classes/NBNAssetCell.m
@@ -12,24 +12,15 @@
     self = [super initWithFrame:frame];
 
     if (self) {
-        _imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
         [self.contentView addSubview:_imageView];
     }
 
     return self;
 }
 
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    self.imageView.frame = CGRectMake(0, 0, NBNAssetCell.size.width, NBNAssetCell.size.height);
-}
-
 - (void)configureWithAsset:(UIImage *)image {
     self.imageView.image = image;
-}
-
-+ (CGSize)size {
-    return CGSizeMake(95, 95);
 }
 
 @end

--- a/Classes/NBNImageCaptureCell.h
+++ b/Classes/NBNImageCaptureCell.h
@@ -5,9 +5,6 @@
 @property (nonatomic, readonly) UIImagePickerController *imagePickerController;
 
 - (void)configureCell;
-
 - (void)removeSubviews;
-
-+ (CGSize)size;
 
 @end

--- a/Classes/NBNImageCaptureCell.m
+++ b/Classes/NBNImageCaptureCell.m
@@ -16,6 +16,7 @@ static UIImagePickerController *imagePickerController;
         _cellSize = frame.size;
         [self setupMaskImageView];
         [self setupImagePicker];
+        self.clipsToBounds = YES;
     }
     return self;
 }

--- a/Classes/NBNImageCaptureCell.m
+++ b/Classes/NBNImageCaptureCell.m
@@ -13,7 +13,7 @@ static UIImagePickerController *imagePickerController;
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.cellSize = frame.size;
+        _cellSize = frame.size;
         [self setupMaskImageView];
         [self setupImagePicker];
     }

--- a/Classes/NBNImageCaptureCell.m
+++ b/Classes/NBNImageCaptureCell.m
@@ -4,6 +4,7 @@ static UIImagePickerController *imagePickerController;
 
 @interface NBNImageCaptureCell ()
 @property (nonatomic) UIImageView *maskImageView;
+@property (nonatomic) CGSize cellSize;
 @end
 
 @implementation NBNImageCaptureCell
@@ -12,6 +13,7 @@ static UIImagePickerController *imagePickerController;
 {
     self = [super initWithFrame:frame];
     if (self) {
+        self.cellSize = frame.size;
         [self setupMaskImageView];
         [self setupImagePicker];
     }
@@ -29,10 +31,9 @@ static UIImagePickerController *imagePickerController;
 }
 
 - (void)configureCell {
-    CGSize cellSize = self.class.size;
-    NBNImageCaptureCell.sharedImagePicker.view.frame = CGRectMake(0, 0, cellSize.width, cellSize.height);
+    NBNImageCaptureCell.sharedImagePicker.view.frame = CGRectMake(0, 0, self.cellSize.width, self.cellSize.height);
     self.maskImageView.image = [UIImage imageNamed:@"NBNPhotoChooser.bundle/camera_cell"];
-    self.maskImageView.frame = CGRectMake(0, 0, cellSize.width, cellSize.height);
+    self.maskImageView.frame = CGRectMake(0, 0, self.cellSize.width, self.cellSize.height);
 }
 
 - (void)removeSubviews {
@@ -53,10 +54,6 @@ static UIImagePickerController *imagePickerController;
 }
 
 #pragma mark - Class Methods
-
-+ (CGSize)size {
-    return CGSizeMake(95, 95);
-}
 
 + (UIImagePickerController *)sharedImagePicker {
     if (!imagePickerController) {

--- a/Classes/NBNPhotoChooserViewController.h
+++ b/Classes/NBNPhotoChooserViewController.h
@@ -11,6 +11,7 @@
 
 @property (nonatomic) NSString *navigationBarTitle;
 @property (nonatomic) NSString *cancelButtonTitle;
+@property (nonatomic) BOOL shouldAnimateImagePickerTransition;
 
 @end
 

--- a/Classes/NBNPhotoChooserViewController.h
+++ b/Classes/NBNPhotoChooserViewController.h
@@ -6,7 +6,7 @@
 
 - (instancetype)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate;
 - (instancetype)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate
-                     maxCellWidth:(CGFloat)maxCellWidth
+                    maxCellWidth:(CGFloat)maxCellWidth
                      cellSpacing:(CGFloat)cellSpacing;
 
 @property (nonatomic) NSString *navigationBarTitle;

--- a/Classes/NBNPhotoChooserViewController.h
+++ b/Classes/NBNPhotoChooserViewController.h
@@ -4,7 +4,10 @@
 
 @interface NBNPhotoChooserViewController : UIViewController
 
-- (id)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate;
+- (instancetype)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate;
+- (instancetype)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate
+                     maxCellWidth:(CGFloat)maxCellWidth
+                     cellSpacing:(CGFloat)cellSpacing;
 
 @property (nonatomic) NSString *navigationBarTitle;
 @property (nonatomic) NSString *cancelButtonTitle;

--- a/Classes/NBNPhotoChooserViewController.h
+++ b/Classes/NBNPhotoChooserViewController.h
@@ -18,6 +18,8 @@
 @protocol NBNPhotoChooserViewControllerDelegate <NSObject>
 
 - (void)photoChooserController:(NBNPhotoChooserViewController *)photoChooser didChooseImage:(UIImage *)image;
+
+@optional
 - (void)photoChooserDidCancel:(NBNPhotoChooserViewController *)photoChooser;
 
 @end

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -109,10 +109,6 @@ static CGFloat const NBNDefaultCellSpacing = 12;
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (BOOL)isCaptureCellInIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == self.images.count && [self hasCamera]) {
         return YES;
@@ -227,12 +223,6 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
 
 - (void)prepareForImagePreviews {
     [self.navigationController setNavigationBarHidden:NO animated:NO];
-}
-
-- (void)toggleCapturingMode {
-    [self.collectionView reloadData];
-    [self scrollToBottom:NO];
-    [self.collectionView setScrollEnabled:!self.collectionView.isScrollEnabled];
 }
 
 - (void)scrollToBottom:(BOOL)animated {

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -32,6 +32,7 @@ static CGFloat const NBNDefaultCellSpacing = 12;
         _delegate = delegate;
         _maxCellWidth = maxCellWidth;
         _cellSpacing = cellSpacing;
+        _shouldAnimateImagePickerTransition = YES;
     }
 
     return self;
@@ -217,7 +218,7 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
         self.imagePickerController.transitioningDelegate = self.transitioningDelegate;
     }
 
-    [self.navigationController presentViewController:self.imagePickerController animated:YES completion:nil];
+    [self.navigationController presentViewController:self.imagePickerController animated:self.shouldAnimateImagePickerTransition completion:nil];
 }
 
 - (void)prepareForFullScreen {
@@ -267,7 +268,9 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info {
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
     picker.showsCameraControls = NO;
-    [picker dismissViewControllerAnimated:YES completion:nil];
+    [picker dismissViewControllerAnimated:self.shouldAnimateImagePickerTransition completion:^{
+        [self.collectionView reloadData];
+    }];
 }
 
 - (void)image:(UIImage *)image didFinishSavingWithError:(NSError *)error contextInfo:(void *)contextInfo {

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -203,15 +203,14 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
 #pragma mark - Image Preview choosing
 
 - (void)didChooseImagePicker {
-    [self.captureCell removeSubviews];
-
     self.imagePickerController = [[UIImagePickerController alloc] init];
     self.imagePickerController.delegate = self;
     self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
     self.imagePickerController.showsCameraControls = YES;
-    if ([self.imagePickerController respondsToSelector:@selector(transitioningDelegate)]) {
+    if (self.shouldAnimateImagePickerTransition && [self.imagePickerController respondsToSelector:@selector(transitioningDelegate)]) {
         self.transitioningDelegate = [[NBNTransitioningDelegate alloc] init];
         self.imagePickerController.transitioningDelegate = self.transitioningDelegate;
+        [self.captureCell removeSubviews];
     }
 
     [self.navigationController presentViewController:self.imagePickerController animated:self.shouldAnimateImagePickerTransition completion:nil];
@@ -257,10 +256,9 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info {
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+    [self scrollToBottom:NO];
     picker.showsCameraControls = NO;
-    [picker dismissViewControllerAnimated:self.shouldAnimateImagePickerTransition completion:^{
-        [self.collectionView reloadData];
-    }];
+    [picker dismissViewControllerAnimated:self.shouldAnimateImagePickerTransition completion:nil];
 }
 
 - (void)image:(UIImage *)image didFinishSavingWithError:(NSError *)error contextInfo:(void *)contextInfo {

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -25,7 +25,7 @@ static CGFloat const NBNDefaultCellSpacing = 12;
 @implementation NBNPhotoChooserViewController
 
 - (instancetype)initWithDelegate:(id<NBNPhotoChooserViewControllerDelegate>)delegate
-                     maxCellWidth:(CGFloat)maxCellWidth
+                    maxCellWidth:(CGFloat)maxCellWidth
                      cellSpacing:(CGFloat)cellSpacing {
     self = [super init];
     if (self) {

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -203,6 +203,7 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
 #pragma mark - Image Preview choosing
 
 - (void)didChooseImagePicker {
+    [self.captureCell removeSubviews];
     self.imagePickerController = [[UIImagePickerController alloc] init];
     self.imagePickerController.delegate = self;
     self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
@@ -210,7 +211,6 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
     if (self.shouldAnimateImagePickerTransition && [self.imagePickerController respondsToSelector:@selector(transitioningDelegate)]) {
         self.transitioningDelegate = [[NBNTransitioningDelegate alloc] init];
         self.imagePickerController.transitioningDelegate = self.transitioningDelegate;
-        [self.captureCell removeSubviews];
     }
 
     [self.navigationController presentViewController:self.imagePickerController animated:self.shouldAnimateImagePickerTransition completion:nil];
@@ -256,7 +256,6 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info {
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-    [self scrollToBottom:NO];
     picker.showsCameraControls = NO;
     [picker dismissViewControllerAnimated:self.shouldAnimateImagePickerTransition completion:nil];
 }


### PR DESCRIPTION
This PR 
- makes the size of the image cells dynamic so that it works on different device types. 
- makes it possible to switch off the custom transition when presenting the `UIImagePickerController`, because it does not work properly when the photo chooser is presented from a modal with presentation style `UIModalPresentationFormSheet`
- removes a method that is never called and a method that is obsolete