### PR TITLE
Removes UIImagePickerController from preview

### DIFF
--- a/Classes/NBNImageCaptureCell.h
+++ b/Classes/NBNImageCaptureCell.h
@@ -2,9 +2,7 @@
 
 @interface NBNImageCaptureCell : NBNCollectionViewCell
 
-@property (nonatomic, readonly) UIImagePickerController *imagePickerController;
-
-- (void)configureCell;
-- (void)removeSubviews;
+- (void)startCapture;
+- (void)stopCapture;
 
 @end

--- a/Classes/NBNImageCaptureCell.m
+++ b/Classes/NBNImageCaptureCell.m
@@ -1,68 +1,71 @@
 #import "NBNImageCaptureCell.h"
-
-static UIImagePickerController *imagePickerController;
+#import <AVFoundation/AVFoundation.h>
 
 @interface NBNImageCaptureCell ()
 @property (nonatomic) UIImageView *maskImageView;
-@property (nonatomic) CGSize cellSize;
+@property (nonatomic, weak) AVCaptureVideoPreviewLayer *previewCaptureLayer;
 @end
 
 @implementation NBNImageCaptureCell
 
-- (id)initWithFrame:(CGRect)frame
+#pragma mark - Init & dealloc
+
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _cellSize = frame.size;
-        [self setupMaskImageView];
         [self setupImagePicker];
+        [self setupMaskImageView];
+        
         self.clipsToBounds = YES;
     }
     return self;
 }
 
+#pragma mark - Setup SubViews
+
 - (void)setupImagePicker {
-    [self.contentView insertSubview:NBNImageCaptureCell.sharedImagePicker.view
-                       belowSubview:self.maskImageView];
+    if (!self.previewCaptureLayer) {
+        AVCaptureSession *captureSession = [[AVCaptureSession alloc] init];
+        AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+        NSError *error = nil;
+        AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+        [captureSession addInput:input];
+        
+        AVCaptureVideoPreviewLayer *captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:captureSession];
+        captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+        [self.contentView.layer addSublayer:captureVideoPreviewLayer];
+        self.previewCaptureLayer = captureVideoPreviewLayer;
+
+        [self startCapture];
+    }
 }
 
 - (void)setupMaskImageView {
     _maskImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+    self.maskImageView.image = [UIImage imageNamed:@"NBNPhotoChooser.bundle/camera_cell"];
     [self.contentView addSubview:_maskImageView];
 }
 
-- (void)configureCell {
-    NBNImageCaptureCell.sharedImagePicker.view.frame = CGRectMake(0, 0, self.cellSize.width, self.cellSize.height);
-    self.maskImageView.image = [UIImage imageNamed:@"NBNPhotoChooser.bundle/camera_cell"];
-    self.maskImageView.frame = CGRectMake(0, 0, self.cellSize.width, self.cellSize.height);
+#pragma mark - Layout
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    self.previewCaptureLayer.frame = self.bounds;
+    self.maskImageView.frame = self.bounds;
 }
 
-- (void)removeSubviews {
-    [NBNImageCaptureCell.sharedImagePicker.view removeFromSuperview];
-}
+#pragma mark - Control Capture
 
-- (void)prepareForReuse {
-    [super prepareForReuse];
-    if (!NBNImageCaptureCell.sharedImagePicker.view.superview) {
-        [self setupImagePicker];
+- (void)startCapture {
+    if (!self.previewCaptureLayer.session.running) {
+         [self.previewCaptureLayer.session startRunning];
     }
 }
 
-#pragma mark - Getter/Setter
-
-- (UIImagePickerController *)imagePickerController {
-    return NBNImageCaptureCell.sharedImagePicker;
-}
-
-#pragma mark - Class Methods
-
-+ (UIImagePickerController *)sharedImagePicker {
-    if (!imagePickerController) {
-        imagePickerController = [[UIImagePickerController alloc] init];
-    }
-    imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
-    imagePickerController.showsCameraControls = NO;
-    return imagePickerController;
+- (void)stopCapture {
+    [self.previewCaptureLayer.session stopRunning];
 }
 
 @end

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -160,8 +160,8 @@ static CGFloat const NBNDefaultCellSpacing = 12;
     NSString *CellIdentifier = [NBNImageCaptureCell reuserIdentifier];
     self.captureCell = [self.collectionView dequeueReusableCellWithReuseIdentifier:CellIdentifier
                                                                                forIndexPath:indexPath];
-
-    [self.captureCell configureCell];
+    [self.captureCell startCapture];
+    
     return self.captureCell;
 }
 
@@ -203,7 +203,7 @@ didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
 #pragma mark - Image Preview choosing
 
 - (void)didChooseImagePicker {
-    [self.captureCell removeSubviews];
+    [self.captureCell stopCapture];
     self.imagePickerController = [[UIImagePickerController alloc] init];
     self.imagePickerController.delegate = self;
     self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;

--- a/Classes/NBNPhotoChooserViewController.m
+++ b/Classes/NBNPhotoChooserViewController.m
@@ -271,11 +271,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info {
 }
 
 - (NSUInteger)supportedInterfaceOrientations {
-    return UIInterfaceOrientationPortrait;
-}
-
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-    return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 @end

--- a/Classes/UIImagePickerController+Orientation.h
+++ b/Classes/UIImagePickerController+Orientation.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface UIImagePickerController (Orientation)
+
+@end

--- a/Classes/UIImagePickerController+Orientation.m
+++ b/Classes/UIImagePickerController+Orientation.m
@@ -1,0 +1,13 @@
+#import "UIImagePickerController+Orientation.h"
+
+@implementation UIImagePickerController (Orientation)
+
+- (BOOL)shouldAutorotate {
+    return NO;
+}
+
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+@end


### PR DESCRIPTION
uses AVCaptureVideoPreviewLayer instead. and enables the picker only for portrait due to some PT/LS issues.