### PR TITLE
only add input to the session if there is an input

### DIFF
--- a/Classes/NBNImageCaptureCell.m
+++ b/Classes/NBNImageCaptureCell.m
@@ -41,7 +41,10 @@
         AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
         NSError *error = nil;
         AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
-        [captureSession addInput:input];
+
+        if (input) {
+            [captureSession addInput:input];
+        }
         
         AVCaptureVideoPreviewLayer *captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:captureSession];
         captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;


### PR DESCRIPTION
This will prevent NSInvalidArgumentException on iOS8 in case the permission for
the camera was revoked in the settings.